### PR TITLE
Use bindnow hardening flag by default

### DIFF
--- a/scripts/Dpkg/Vendor/Debian.pm
+++ b/scripts/Dpkg/Vendor/Debian.pm
@@ -287,7 +287,7 @@ sub _add_hardening_flags {
 	fortify => 1,
 	format => 1,
 	relro => 1,
-	bindnow => 0,
+	bindnow => 1,
     );
     my %builtin_feature = (
         pie => 1,


### PR DESCRIPTION
Please enable bindnow, since it is not enabled in gcc anymore.
See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=835146.